### PR TITLE
Renamed ItemSchema to ClientSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ import { LocalizationParser } from "@mann-conomy/tf-parser";
 })();
 ```
 
-Parsing the item schema from the Steam Web API.
+Parsing the client schema from the Steam Web API.
 
 ```js
 import { SchemaParser } from "@mann-conomy/tf-parser";
 
 (async() => {
     try {
-        // Fetch the item schema from the Steam Web API
+        // Fetch the client schema from the Steam Web API
         const response = await fetch("https://media.steampowered.com/apps/440/scripts/items/items_game.bdc614ad776fb2d43c1f247fce870485d2299152.txt");
 
         // Resolve the response into a UTF-8 string

--- a/examples/schema.ts
+++ b/examples/schema.ts
@@ -2,7 +2,7 @@ import { SchemaParser } from "../src/index";
 
 (async() => {
     try {
-        // Fetch the item schema from the Steam Web API
+        // Fetch the client schema from the Steam Web API
         const response = await fetch("https://media.steampowered.com/apps/440/scripts/items/items_game.bdc614ad776fb2d43c1f247fce870485d2299152.txt");
 
         // Resolve the response into a UTF-8 string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mann-conomy/tf-parser",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mann-conomy/tf-parser",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@mann-conomy/vdf-utils": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mann-conomy/tf-parser",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A Node.js parser for converting Team Fortress 2 game files to JSON objects.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/classes/parsers/schema.ts
+++ b/src/classes/parsers/schema.ts
@@ -1,17 +1,17 @@
 import { VDF } from "@mann-conomy/vdf-utils";
-import type { ItemSchema } from "../../types/schema";
+import type { ClientSchema } from "../../types/schema";
 
 /**
- * A parser for converting Team Fortress 2 item schemas to JSON objects.
+ * A parser for converting Team Fortress 2 client schemas to JSON objects.
  */
 export default class SchemaParser {
     /**
-     * Parses a Team Fortress 2 item schema to JSON.
-     * @param schema The content of a Team Fortress 2 item schema.
-     * @returns The item schema as a JSON object.
-     * @throws A RangeError if the item schema results in an empty JSON object.
+     * Parses a Team Fortress 2 client schema to JSON.
+     * @param schema The content of a Team Fortress 2 client schema.
+     * @returns The client schema as a JSON object.
+     * @throws A RangeError if the client schema results in an empty JSON object.
      */
-    public static parse(schema: string): ItemSchema {
-        return VDF.parse<ItemSchema>(schema);
+    public static parse(schema: string): ClientSchema {
+        return VDF.parse<ClientSchema>(schema);
     }
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -3798,9 +3798,9 @@ export interface WarDefinition {
 }
 
 /**
- * Represents a Team Fortress 2 item schema parsed into a JSON object.
+ * Represents the Team Fortress 2 client schema parsed into a JSON object.
  */
-export interface ItemSchema {
+export interface ClientSchema {
     items_game: {
         game_info: Record<string, string>;
         qualities: Record<string, ItemQuality>;

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -10,9 +10,9 @@ describe("SchemaParser", () => {
         expect(parser).toBeInstanceOf(SchemaParser);
     });
 
-    test("should return item schema tokens given a valid file string", () => {
+    test("should return client schema tokens given a valid file string", () => {
         // Arrange
-        const file = createItemSchema();
+        const file = createClientSchema();
 
         // Act
         const { items_game } = SchemaParser.parse(file);
@@ -49,9 +49,9 @@ describe("SchemaParser", () => {
 });
 
 /**
- * Creates a mock string of a Team Fortress 2 item schema.
- * @returns { string } A mock string of a Team Fortress 2 item schema.
+ * Creates a mock string of a Team Fortress 2 client schema.
+ * @returns { string } A mock string of a Team Fortress 2 client schema.
  */
-function createItemSchema(): string {
+function createClientSchema(): string {
     return "\"items_game\"\n\{\n\"qualities\"\n{\n\"vintage\"\n{\n\"value\"\t\"3\"\n}\n\"strange\"\n{\n\"value\"\t\"11\"\n}\n}";
 }


### PR DESCRIPTION
* Renamed ItemSchema -> ClientSchema to prevent conflicts in the upcoming tf-schema library.